### PR TITLE
Add autonyms for bcl and br to the static test page

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -1,7 +1,9 @@
 let languages = {}
 const AUTONYMS = {
     as: 'অসমীয়া',
+    bcl: 'Bikol Sentral',
     bn: 'বাংলা',
+    br: 'brezhoneg',
     cy: 'Cymraeg',
     en: 'English',
     es: 'español',


### PR DESCRIPTION
We are testing these for Wikimedia at https://opusmt.wmflabs.org/ ,
and it would be nice to see correct language names.