### PR TITLE
Minimise the size of the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM debian:stable
+# This is a two-stage Docker build where we use a more fully featured Debian
+# image to build Marian and the required Python modules, then copy the built
+# artifacts into a much smaller final image.
+
+FROM debian:stable as builder
 
 WORKDIR /usr/src/app
 
@@ -10,7 +14,7 @@ RUN set -eux; \
 		automake autogen libtool cmake-data cmake unzip \
 		libboost-all-dev libblas-dev libopenblas-dev libz-dev libssl-dev \
 		libprotobuf17 protobuf-compiler libprotobuf-dev \
-		python3-dev python3-pip python3-setuptools python3-websocket;
+		python3-dev python3-pip python3-setuptools python3-websocket python3-venv;
 
 # Install Intel libraries
 RUN set -eux; \
@@ -22,30 +26,49 @@ RUN set -eux; \
 		intel-mkl-64bit-2019.5-075; \
 	rm -f GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB;
 
-# Install Marian MT
+
+# Build Marian, using static libraries so we can simply pluck the compiled
+# marian-server out later
 RUN set -eux; \
 	git clone https://github.com/marian-nmt/marian marian; \
 	cd marian; \
 	git checkout 1.9.0; \
-	cmake . -DCOMPILE_SERVER=on -DUSE_SENTENCEPIECE=on -DCOMPILE_CPU=on -DCOMPILE_CUDA=off;  \
-	make -j4;
+	cmake . -DUSE_STATIC_LIBS=on -DCOMPILE_SERVER=on -DUSE_SENTENCEPIECE=on -DCOMPILE_CPU=on -DCOMPILE_CUDA=off;  \
+	make -j4 marian_server ;
+
+COPY requirements.txt .
+
+# Install python requirements.  First we upgrade to the latest pip so it can
+# support "manylinux2014" binary wheels.
+
+RUN set -eux; \
+        python3 -mvenv venv ; venv/bin/pip install --upgrade pip ; \
+	venv/bin/pip install -r requirements.txt
+
+
+# Start over from the minimal "slim" python base image
+FROM python:3.7-slim
+
+WORKDIR /usr/src/app
+
+# Include just the marian-server binary and the Python virtual environment from
+# the build image - we don't need all the Marian sources, intermediate build
+# artifacts, other Marian binaries, MKL libraries, etc.
+COPY --from=builder /usr/src/app/marian/marian-server /usr/local/bin
+COPY --from=builder /usr/src/app/venv /usr/src/app/venv/
+
+# Install perl modules required by moses, and fix up the venv as python is
+# in a different place in the "python" base image compared to where apt
+# installs it in debian:stable
+RUN set -ex ; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends perl ; \
+        rm -rf /var/lib/apt/lists/* ; \
+        ln -sf /usr/local/bin/python3 /usr/src/app/venv/bin/python3
 
 COPY . .
 
-# Install python requirements.
-
-RUN set -eux; \
-	pip3 install -r requirements.txt
-
-# install services
-RUN install -m 755 marian/marian /usr/local/bin/; \
-	install -m 755 marian/marian-server /usr/local/bin/; \
-	install -m 755 marian/marian-server /usr/local/bin/; \
-	install -m 755 marian/marian-vocab /usr/local/bin/; \
-	install -m 755 marian/marian-decoder /usr/local/bin/; \
-	install -m 755 marian/marian-scorer /usr/local/bin/; \
-	install -m 755 marian/marian-conv /usr/local/bin/; \
-	install -m 644 marian/libmarian.a  /usr/local/lib/;
-
 EXPOSE 80
-CMD python3 server.py -c services.json -p 80
+
+# Run using the virtual environment Python
+CMD ["venv/bin/python", "server.py", "-c", "services.json", "-p", "80"]


### PR DESCRIPTION
The current Dockerfile in Opus-MT leaves a large amount of un-necessary data in the image, such as the full Marian source tree, multiple copies of all the Marian binaries, as well as a large number of apt packages that are required in order to _build_ the tools but not to _run_ them.  This makes for an extremely large final image (in the region of 10GB not including any models).  While this isn't too much of a concern if you're just building the image locally as part of a `docker-compose`, if you want to push the image to a registry for use by others (or to run under Kubernetes) then it pays to keep the image as small as possible.

This PR uses a multi-stage Docker build to minimise the final image size.  The build container is still large - that's unavoidable - but for the final container the Dockerfile now starts over from a "slim" Python base image and copies across only the required `marian-server` binary, Python packages and a few other dependencies that are actually required at runtime.  This brings the final image size down to under 600MB (again, not including any models).