### PR TITLE
Use "buster" version of the slim python base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN set -eux; \
 
 
 # Start over from the minimal "slim" python base image
-FROM python:3.7-slim
+FROM python:3.7-slim-buster
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -48,7 +48,7 @@ RUN set -eux; \
 
 
 # Start over from the minimal "slim" python base image
-FROM python:3.7-slim
+FROM python:3.7-slim-buster
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The second stage of the Docker build starts from a python image based on a "slim" Debian - since the first stage builder now explicitly refers to Debian "buster" rather than the latest "stable" we should do the same with the second stage to ensure libraries remain compatible.