### PR TITLE
Fix/libprotobuf23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /usr/src/app
 
 # Install base packages
 RUN set -eux; \
+    sh -c 'echo deb http://deb.debian.org/debian buster-backports main > /etc/apt/sources.list.d/buster-backports.list'; \
 	apt-get update; \
 	apt-get install -y --no-install-recommends \
 		ca-certificates git wget gnupg build-essential lsb-release g++ \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   opus-mt:
     build: .
     volumes:
-      - .:/usr/src/app
+      - ./models:/usr/src/app/models
     ports:
       - 8888:80
 


### PR DESCRIPTION
These commits correct two errors causing the docker build instructions in the readme to fail:

- The needed libprotobuf version 23 is found in buster-backports.
- The over-eager volume mount masks the virtual env. Restricting it to mounting the models solves the problem.

Closes #53
(which was a duplicate of #44, which seems to have been prematurely closed)