### PR TITLE
Fixed GPU dockerfile as old nvidia base image no longer exists

### DIFF
--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,7 +1,7 @@
 # This is a two-stage Docker build for GPU where we first use the complete Nvidia CUDA Debian image to build Marian-NMT
 # and then copy only the necessary artifacts into the much lighter Nvidia CUDA Runtime final image
 
-FROM nvidia/cuda:11.3.0-devel-ubuntu20.04 AS builder
+FROM nvidia/cuda:11.3.1-devel-ubuntu20.04 AS builder
 
 ENV MARIANPATH /marian
 
@@ -33,17 +33,11 @@ RUN set -eux; \
 		gnupg \
 		software-properties-common \
 		cmake \
+		intel-mkl \
 		python3-dev \
 		python3-pip \
 		python3-venv; \
 	rm -rf /var/lib/apt/lists/*;
-
-RUN set -eux; \
-	wget -qO- 'https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB' | apt-key add -; \
-	sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list'; \
-	apt-get update; \
-	apt-get install -yq --no-install-recommends \
-		intel-mkl-64bit-2020.0-088;
 
 # Install Marian
 RUN set -eux; \
@@ -63,7 +57,7 @@ RUN set -eux; \
 		venv/bin/pip install -r requirements.txt;
 
 # The second stage is based on the smaller CUDA Runtime image
-FROM nvidia/cuda:11.3.0-runtime-ubuntu20.04
+FROM nvidia/cuda:11.3.1-runtime-ubuntu20.04
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
`nvidia/cuda:11.3.0-devel-ubuntu20.04` is no longer available from Docker Hub, so I've replaced that with `nvidia/cuda:11.3.1-devel-ubuntu20.04`.  Also the Intel APT repository is no longer active, but a compatible version of the library is available from Ubuntu's own apt repository, so I've taken out the specific Intel section and simply installed `intel-mkl` as part of the main `apt-get install`.

A similar fix for the intel libraries will be needed for the CPU build, but I'm not sure exactly what the fix is there as the build uses `debian:buster` instead of an Ubuntu-based image.